### PR TITLE
[SPARK-21122][CORE][YARN][WIP] Address starvation issues when dynamic allocation is enabled

### DIFF
--- a/core/src/main/scala/org/apache/spark/ExecutorAllocationManager.scala
+++ b/core/src/main/scala/org/apache/spark/ExecutorAllocationManager.scala
@@ -26,9 +26,10 @@ import scala.util.control.{ControlThrowable, NonFatal}
 import com.codahale.metrics.{Gauge, MetricRegistry}
 
 import org.apache.spark.internal.Logging
-import org.apache.spark.internal.config.{DYN_ALLOCATION_MAX_EXECUTORS, DYN_ALLOCATION_MIN_EXECUTORS}
+import org.apache.spark.internal.config._
 import org.apache.spark.metrics.source.Source
 import org.apache.spark.scheduler._
+import org.apache.spark.scheduler.cluster.CoarseGrainedClusterMessages.PreemptExecutors
 import org.apache.spark.util.{Clock, SystemClock, ThreadUtils, Utils}
 
 /**
@@ -130,7 +131,7 @@ private[spark] class ExecutorAllocationManager(
   private val executorsPendingToRemove = new mutable.HashSet[String]
 
   // All known executors
-  private val executorIds = new mutable.HashSet[String]
+  private[spark] val executorIds = new mutable.HashSet[String]
 
   // A timestamp of when an addition should be triggered, or NOT_SET if it is not set
   // This is set when pending tasks are added but not scheduled yet
@@ -138,7 +139,7 @@ private[spark] class ExecutorAllocationManager(
 
   // A timestamp for each executor of when the executor should be removed, indexed by the ID
   // This is set when an executor is no longer running a task, or when it first registers
-  private val removeTimes = new mutable.HashMap[String, Long]
+  private[spark] val removeTimes = new mutable.HashMap[String, Long]
 
   // Polling loop interval (ms)
   private val intervalMillis: Long = 100
@@ -155,6 +156,11 @@ private[spark] class ExecutorAllocationManager(
 
   // Metric source for ExecutorAllocationManager to expose internal status to MetricsSystem.
   val executorAllocationManagerSource = new ExecutorAllocationManagerSource
+
+  // Preemption policy state
+  private[spark] val preemptableExecutors = new mutable.HashSet[String]
+  private val policy = PreemptionPolicy
+    .mkPolicy(conf, executorIds, removeTimes, preemptableExecutors)
 
   // Whether we are still waiting for the initial set of executors to be allocated.
   // While this is true, we will not cancel outstanding executor requests. This is
@@ -256,6 +262,7 @@ private[spark] class ExecutorAllocationManager(
     numExecutorsTarget = initialNumExecutors
     executorsPendingToRemove.clear()
     removeTimes.clear()
+    preemptableExecutors.clear()
   }
 
   /**
@@ -284,6 +291,11 @@ private[spark] class ExecutorAllocationManager(
     val now = clock.getTimeMillis
 
     updateAndSyncNumExecutorsTarget(now)
+
+    if (preemptableExecutors.nonEmpty) {
+      removeExecutors(preemptableExecutors.toSeq, forceKill = true)
+      preemptableExecutors.clear()
+    }
 
     val executorIdsToBeRemoved = ArrayBuffer[String]()
     removeTimes.retain { case (executorId, expireTime) =>
@@ -420,7 +432,9 @@ private[spark] class ExecutorAllocationManager(
    * Request the cluster manager to remove the given executors.
    * Returns the list of executors which are removed.
    */
-  private def removeExecutors(executors: Seq[String]): Seq[String] = synchronized {
+  private def removeExecutors(
+      executors: Seq[String],
+      forceKill: Boolean = false): Seq[String] = synchronized {
     val executorIdsToBeRemoved = new ArrayBuffer[String]
 
     logInfo("Request to remove executorIds: " + executors.mkString(", "))
@@ -428,10 +442,10 @@ private[spark] class ExecutorAllocationManager(
 
     var newExecutorTotal = numExistingExecutors
     executors.foreach { executorIdToBeRemoved =>
-      if (newExecutorTotal - 1 < minNumExecutors) {
+      if (!forceKill && newExecutorTotal - 1 < minNumExecutors) {
         logDebug(s"Not removing idle executor $executorIdToBeRemoved because there are only " +
           s"$newExecutorTotal executor(s) left (minimum number of executor limit $minNumExecutors)")
-      } else if (newExecutorTotal - 1 < numExecutorsTarget) {
+      } else if (!forceKill && newExecutorTotal - 1 < numExecutorsTarget) {
         logDebug(s"Not removing idle executor $executorIdToBeRemoved because there are only " +
           s"$newExecutorTotal executor(s) left (number of executor target $numExecutorsTarget)")
       } else if (canBeKilled(executorIdToBeRemoved)) {
@@ -448,7 +462,7 @@ private[spark] class ExecutorAllocationManager(
     val executorsRemoved = if (testing) {
       executorIdsToBeRemoved
     } else {
-      client.killExecutors(executorIdsToBeRemoved)
+      client.killExecutors(executorIdsToBeRemoved, force = forceKill)
     }
     // [SPARK-21834] killExecutors api reduces the target number of executors.
     // So we need to update the target with desired value.
@@ -595,6 +609,10 @@ private[spark] class ExecutorAllocationManager(
   private def onExecutorBusy(executorId: String): Unit = synchronized {
     logDebug(s"Clearing idle timer for $executorId because it is now running a task")
     removeTimes.remove(executorId)
+  }
+
+  def preemptExecutors(ypm: PreemptExecutors): Unit = synchronized {
+    policy.preemptExecutors(ypm)
   }
 
   /**

--- a/core/src/main/scala/org/apache/spark/PreemptionPolicy.scala
+++ b/core/src/main/scala/org/apache/spark/PreemptionPolicy.scala
@@ -1,0 +1,122 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark
+
+import java.lang.reflect.Constructor
+
+import scala.collection.mutable
+
+import org.apache.spark.internal.config.DYN_ALLOCATION_PREEMPTION_POLICY
+import org.apache.spark.scheduler.cluster.CoarseGrainedClusterMessages.PreemptExecutors
+import org.apache.spark.util.Utils
+
+/**
+ * PreemptionPolicy companion object abstracts loading the
+ * `DYN_ALLOCATION_PREEMPTION_POLICY`.
+ */
+object PreemptionPolicy {
+  private def getCtor(conf: SparkConf): Constructor[_] = {
+    Utils
+      .classForName(conf.get(DYN_ALLOCATION_PREEMPTION_POLICY))
+      .getConstructor(
+        classOf[mutable.HashSet[String]],
+        classOf[mutable.HashMap[String, Long]],
+        classOf[mutable.HashSet[String]]
+      )
+  }
+
+  def mkPolicy(
+      conf: SparkConf,
+      executorIds: mutable.HashSet[String],
+      removeTimes: mutable.HashMap[String, Long],
+      preemptedExecutors: mutable.HashSet[String]): PreemptionPolicy = {
+    getCtor(conf)
+      .newInstance(executorIds, removeTimes, preemptedExecutors)
+      .asInstanceOf[PreemptionPolicy]
+  }
+}
+
+/**
+ * The preemptExecutors method is synchronized in the ExecutorAllocationManager (EAM),
+ * so it's not necessary here. But still...beware.
+ *
+ * @param executorIds mutable collection of executorIds (not mutatated by default)
+ * @param removeTimes EAM's idle executor -> expiration map (not mutated by default)
+ * @param preemptedExecutors mutable collection of executors to be preempted on the next
+ *                           EAM update. preemptExecutors adds to this set, but EAM acts
+ *                           on and clears the set
+ */
+abstract class PreemptionPolicy(
+    executorIds: mutable.HashSet[String],
+    removeTimes: mutable.HashMap[String, Long],
+    preemptedExecutors: mutable.HashSet[String]) {
+  def preemptExecutors(ypm: PreemptExecutors): Unit
+}
+
+/**
+ * DefaultPreemptionPolicy is the default preemption policy selected when
+ * DYN_ALLOCATION_PREEMPTION_POLICY is not set. This policy was created with YARN's
+ * PreemptionMessage symantics in mind. Instead of simply killing YARN's requested
+ * containers, preemptively remove idle executors without cached data. If YARN requests
+ * to preempt more executors than are idle, include the `askedToLeave` set and randomly
+ * select executors to fill out the total preemption count.
+ */
+class DefaultPreemptionPolicy(
+    executorIds: mutable.HashSet[String],
+    removeTimes: mutable.HashMap[String, Long],
+    preemptedExecutors: mutable.HashSet[String]) extends
+  PreemptionPolicy(executorIds, removeTimes, preemptedExecutors) {
+
+  protected[spark] def orderByPreemtableness(
+      execMap: mutable.HashMap[String, Long],
+      numExecs: Int): Seq[String] = {
+    execMap.toSeq.sortBy(_._2).take(numExecs).map(_._1)
+  }
+
+  /**
+   * find executors to offer up for preemption
+   * favor most idle executors without cached data
+   * NOTE: does not consider non-idle executors
+   */
+  protected[spark] def findPreemptableExecutors(numExecsToKill: Int): Seq[String] = {
+    val blockMaster = SparkEnv.get.blockManager.master
+    val (execsWithCachedData, execsWithoutCachedData) = removeTimes
+      .partition { case (id, _) => blockMaster.hasCachedBlocks(id) }
+    if (execsWithoutCachedData.size < numExecsToKill) {
+      val execsLeftToKill = numExecsToKill - execsWithoutCachedData.size
+      execsWithoutCachedData.keys.toSeq ++
+        orderByPreemtableness(execsWithCachedData, execsLeftToKill)
+    } else orderByPreemtableness(execsWithoutCachedData, numExecsToKill)
+  }
+
+  override def preemptExecutors(ypm: PreemptExecutors): Unit = {
+    val execsAskedToLeave = ypm.numRequestedContainers
+    val numExecsToPreempt = ypm.forcedToLeave.size + execsAskedToLeave
+    val execsToPreempt = mutable.LinkedHashSet(ypm.forcedToLeave.toSeq: _*)
+    if (execsAskedToLeave > 0) {
+      execsToPreempt ++= findPreemptableExecutors(execsAskedToLeave)
+      execsToPreempt ++= ypm.askedToLeave
+      val remaining = numExecsToPreempt - execsToPreempt.size
+      if (remaining > 0) execsToPreempt ++= scala.util.Random.shuffle(executorIds).take(remaining)
+    }
+
+    if (numExecsToPreempt > 0 && execsToPreempt.nonEmpty) {
+      preemptedExecutors ++= execsToPreempt.take(numExecsToPreempt)
+    }
+  }
+}

--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -102,6 +102,15 @@ package object config {
   private[spark] val SHUFFLE_SERVICE_ENABLED =
     ConfigBuilder("spark.shuffle.service.enabled").booleanConf.createWithDefault(false)
 
+  private[spark] val DYN_ALLOCATION_PREEMPTION_POLICY_DEFAULT =
+    "org.apache.spark.DefaultPreemptionPolicy"
+
+  private[spark] val DYN_ALLOCATION_PREEMPTION_POLICY =
+    ConfigBuilder("spark.dynamicAllocation.preemption.policy")
+      .doc("Fully qualified classname for preemption policy.")
+      .stringConf
+      .createWithDefault(DYN_ALLOCATION_PREEMPTION_POLICY_DEFAULT)
+
   private[spark] val KEYTAB = ConfigBuilder("spark.yarn.keytab")
     .doc("Location of user's keytab.")
     .stringConf.createOptional

--- a/core/src/main/scala/org/apache/spark/scheduler/cluster/CoarseGrainedClusterMessage.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/cluster/CoarseGrainedClusterMessage.scala
@@ -116,6 +116,12 @@ private[spark] object CoarseGrainedClusterMessages {
 
   case class KillExecutors(executorIds: Seq[String]) extends CoarseGrainedClusterMessage
 
+  case class PreemptExecutors(
+      forcedToLeave: Set[String],
+      askedToLeave: Set[String],
+      numRequestedContainers: Int)
+    extends CoarseGrainedClusterMessage
+
   // Used internally by executors to shut themselves down.
   case object Shutdown extends CoarseGrainedClusterMessage
 

--- a/core/src/test/scala/org/apache/spark/PreemptionPolicySuite.scala
+++ b/core/src/test/scala/org/apache/spark/PreemptionPolicySuite.scala
@@ -1,0 +1,147 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark
+
+import scala.collection.mutable
+
+import org.scalatest.Matchers
+
+import org.apache.spark.scheduler.cluster.CoarseGrainedClusterMessages.PreemptExecutors
+
+class PreemptionPolicySuite extends SparkFunSuite
+  with LocalSparkContext with Matchers {
+
+  override def beforeEach(): Unit = sc = mkSparkContext()
+
+  private def mkSparkContext(
+    minExecutors: Int = 1,
+    maxExecutors: Int = 4,
+    initialExecutors: Int = 1): SparkContext = {
+    val conf = new SparkConf()
+      .setMaster("myDummyLocalExternalClusterManager")
+      .setAppName("test-executor-allocation-manager")
+      .set("spark.dynamicAllocation.enabled", "true")
+      .set("spark.dynamicAllocation.minExecutors", minExecutors.toString)
+      .set("spark.dynamicAllocation.maxExecutors", maxExecutors.toString)
+      .set("spark.dynamicAllocation.initialExecutors", initialExecutors.toString)
+      .set("spark.dynamicAllocation.testing", "true")
+    new SparkContext(conf)
+  }
+
+  test("reflect to get the default policy") {
+    val executorIds = new mutable.HashSet[String]
+    val removeTimes = new mutable.HashMap[String, Long]
+    val preemptedExecutors = new mutable.HashSet[String]
+
+    val conf = new SparkConf()
+      .setMaster("myDummyLocalExternalClusterManager")
+      .setAppName("test-executor-allocation-manager")
+    val policy = PreemptionPolicy.mkPolicy(conf, executorIds, removeTimes, preemptedExecutors)
+
+    policy should not be null
+    val ypm = PreemptExecutors(Set.empty, Set.empty, 0)
+    policy.preemptExecutors(ypm)
+    preemptedExecutors should have size 0
+  }
+
+  test("preemption selection with forced removal") {
+    sc.executorAllocationManager shouldBe defined
+    val eam = sc.executorAllocationManager.get
+    val numExecs = 2
+    eam.executorIds ++= scala.util.Random.shuffle((0 until 4).map(_.toString))
+    val rmex = scala.util.Random.shuffle(eam.executorIds).take(numExecs).toSet
+    val ypm = PreemptExecutors(rmex, Set.empty, 0)
+    eam.preemptExecutors(ypm)
+    eam.preemptableExecutors should have size numExecs
+    eam.preemptableExecutors.foreach { pe =>
+      rmex should contain (pe)
+    }
+  }
+
+  test("preemption selection with asked removal and no idle execs") {
+    sc.executorAllocationManager shouldBe defined
+    val eam = sc.executorAllocationManager.get
+    val numExecs = 1
+    eam.executorIds ++= scala.util.Random.shuffle((0 until 4).map(_.toString))
+    val rmex = scala.util.Random.shuffle(eam.executorIds).take(numExecs).toSet
+    val ypm = PreemptExecutors(Set.empty, rmex, numExecs)
+    eam.preemptExecutors(ypm)
+    eam.preemptableExecutors should have size numExecs
+    eam.preemptableExecutors.foreach { pe =>
+      rmex should contain (pe)
+    }
+  }
+
+  test("preemption selection with asked removal and idle execs") {
+    sc.executorAllocationManager shouldBe defined
+    val eam = sc.executorAllocationManager.get
+    val numExecs = 1
+    eam.executorIds ++= scala.util.Random.shuffle((0 until 4).map(_.toString))
+    val head = eam.executorIds.head
+    eam.removeTimes(eam.executorIds.takeRight(1).head) = System.currentTimeMillis + 1000L
+    val rmex = scala.util.Random.shuffle(eam.executorIds).take(numExecs).toSet
+    val ypm = PreemptExecutors(Set.empty, rmex, 2)
+    eam.preemptExecutors(ypm)
+    eam.preemptableExecutors should have size 2
+    eam.preemptableExecutors should contain (head)
+    eam.preemptableExecutors should contain (rmex.head)
+  }
+
+  test("preemption selection with no asked removal and idle execs") {
+    sc.executorAllocationManager shouldBe defined
+    val eam = sc.executorAllocationManager.get
+    val numExecs = 2
+    eam.executorIds ++= scala.util.Random.shuffle((0 until 4).map(_.toString))
+    val idleExecs = new mutable.HashSet[String]
+    eam.executorIds.takeRight(numExecs).foreach { eid =>
+      eam.removeTimes(eid) = System.currentTimeMillis + 1000L
+      idleExecs.add(eid)
+    }
+
+    val ypm = PreemptExecutors(Set.empty, Set.empty, numExecs)
+    eam.preemptExecutors(ypm)
+    eam.preemptableExecutors should have size numExecs
+    eam.preemptableExecutors.foreach { eid =>
+      idleExecs should contain (eid)
+    }
+  }
+
+  test("test ordering") {
+    val executorIds = new mutable.HashSet[String]
+    val removeTimes = new mutable.HashMap[String, Long]
+    val preemptedExecutors = new mutable.HashSet[String]
+
+    val conf = new SparkConf()
+      .setMaster("myDummyLocalExternalClusterManager")
+      .setAppName("test-executor-allocation-manager")
+    val policy = PreemptionPolicy
+      .mkPolicy(conf, executorIds, removeTimes, preemptedExecutors)
+      .asInstanceOf[DefaultPreemptionPolicy]
+    val execMap = new mutable.HashMap[String, Long]
+    execMap += "1" -> 13L
+    execMap += "2" -> 11L
+    execMap += "3" -> 10L
+    execMap += "4" -> 12L
+    execMap += "5" -> 9L
+    execMap += "6" -> 8L
+
+    val res = policy.orderByPreemtableness(execMap, 4)
+    res should have size 4
+    res shouldBe Seq("6", "5", "3", "2")
+  }
+}

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1725,6 +1725,14 @@ Apart from these, the following properties are also available, and may be useful
     <a href="job-scheduling.html#resource-allocation-policy">description</a>.
   </td>
 </tr>
+<tr>
+  <td><code>spark.dynamicAllocation.preemption.policy</code></td>
+  <td><code>org.apache.spark.DefaultPreemptionPolicy</code></td>
+  <td>
+    Preemption policy to use when selecting executors for removal when a PreemptionMessage
+    is received. This should be the fully qualified classname to the policy.
+  </td>
+</tr>
 </table>
 
 ### Security

--- a/resource-managers/yarn/src/main/scala/org/apache/spark/scheduler/cluster/YarnSchedulerBackend.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/scheduler/cluster/YarnSchedulerBackend.scala
@@ -17,9 +17,9 @@
 
 package org.apache.spark.scheduler.cluster
 
-import java.util.concurrent.atomic.{AtomicBoolean}
+import java.util.concurrent.atomic.AtomicBoolean
 
-import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.Future
 import scala.util.{Failure, Success}
 import scala.util.control.NonFatal
 
@@ -271,6 +271,8 @@ private[spark] abstract class YarnSchedulerBackend(
             logError("Error requesting driver to remove executor" +
               s" $executorId for reason $reason", e)
         }(ThreadUtils.sameThread)
+
+      case ypm: PreemptExecutors => sc.executorAllocationManager.foreach(_.preemptExecutors(ypm))
     }
 
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

When dynamic resource allocation is enabled on a cluster, it’s currently possible for one application to consume all the cluster’s resources, effectively starving any other application trying to start. This is particularly painful in a notebook environment where notebooks may be idle for tens of minutes while the user is figuring out what to do next (or eating their lunch). Ideally the application should give resources back to the cluster when monitoring indicates other applications are pending.

## How was this patch tested?

Unit tests and manual testing. Unit tests are in `PreemptionPolicySuite.scala`. Manual testing

Please review http://spark.apache.org/contributing.html before opening a pull request.
